### PR TITLE
Update build user

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         name: Prepare
         id: prepare
         run: |
-          DOCKER_USERNAME=matthewgall
+          DOCKER_USERNAME=buildsocietybot
           DOCKER_IMAGE=buildsociety/cloudflared
           DOCKER_PLATFORMS=linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386,linux/ppc64le,linux/s390x
           VERSION=edge


### PR DESCRIPTION
Currently, images are built and pushed via a matthewgall user, which is a little weird. Now we're going to use a new user, buildsocietybot